### PR TITLE
Add token broker for HMRC with automatic refresh

### DIFF
--- a/src/SFA.DAS.TokenService.Api/Controllers/PrivilegedAccessController.cs
+++ b/src/SFA.DAS.TokenService.Api/Controllers/PrivilegedAccessController.cs
@@ -23,7 +23,6 @@ namespace SFA.DAS.TokenService.Api.Controllers
         [HttpGet]
         [Route("", Name = "GetPrivilegedAccessToken")]
         //[Authorize(Roles = "ReadPrivilegedAccessToken")]
-        [Authorize]
         public async Task<IHttpActionResult> GetPrivilegedAccessToken()
         {
             try

--- a/src/SFA.DAS.TokenService.Api/Controllers/PrivilegedAccessController.cs
+++ b/src/SFA.DAS.TokenService.Api/Controllers/PrivilegedAccessController.cs
@@ -23,6 +23,7 @@ namespace SFA.DAS.TokenService.Api.Controllers
         [HttpGet]
         [Route("", Name = "GetPrivilegedAccessToken")]
         //[Authorize(Roles = "ReadPrivilegedAccessToken")]
+        [Authorize]
         public async Task<IHttpActionResult> GetPrivilegedAccessToken()
         {
             try

--- a/src/SFA.DAS.TokenService.Api/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.TokenService.Api/DependencyResolution/IoC.cs
@@ -27,6 +27,7 @@ namespace SFA.DAS.TokenService.Api.DependencyResolution {
                 c.Policies.Add<LoggingPolicy>();
                 c.Policies.Add(new StructureMapExecutionPolicy());
                 c.AddRegistry<DefaultRegistry>();
+                c.AddRegistry<TokenRefreshRegistry>();
             });
         }
     }

--- a/src/SFA.DAS.TokenService.Api/DependencyResolution/TokenRefreshRegistry.cs
+++ b/src/SFA.DAS.TokenService.Api/DependencyResolution/TokenRefreshRegistry.cs
@@ -1,0 +1,20 @@
+using SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh;
+using SFA.DAS.TokenService.Infrastructure.Configuration;
+using StructureMap;
+using StructureMap.Graph;
+
+namespace SFA.DAS.TokenService.Api.DependencyResolution
+{
+
+    public class TokenRefreshRegistry : Registry
+    {
+        public TokenRefreshRegistry()
+        {
+            For<ITokenRefresher>().Use<TokenRefresher>().Singleton();
+            For<IHmrcAuthTokenBroker>().Use<HmrcAuthTokenBroker>().Singleton();
+            For<TokenRefresherParameters>().Use(new TokenRefresherParameters() {TokenRefreshExpirationPercentage = 80})
+                .Singleton();
+            For<ITokenRefreshAudit>().Use(new TokenRefreshAudit(false)).Singleton();
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Api/SFA.DAS.TokenService.Api.csproj
+++ b/src/SFA.DAS.TokenService.Api/SFA.DAS.TokenService.Api.csproj
@@ -24,6 +24,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -231,6 +232,7 @@
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\HealthCheckController.cs" />
     <Compile Include="Controllers\PrivilegedAccessController.cs" />
+    <Compile Include="DependencyResolution\TokenRefreshRegistry.cs" />
     <Compile Include="DependencyResolution\DefaultRegistry.cs" />
     <Compile Include="DependencyResolution\IoC.cs" />
     <Compile Include="DependencyResolution\StructureMapDependencyScope.cs" />

--- a/src/SFA.DAS.TokenService.Api/SFA.DAS.TokenService.Api.csproj
+++ b/src/SFA.DAS.TokenService.Api/SFA.DAS.TokenService.Api.csproj
@@ -143,13 +143,8 @@
       <HintPath>..\packages\StackExchange.Redis.1.1.608\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=4.2.0.402, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.2.0.402\lib\net40\StructureMap.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="StructureMap.Net4, Version=4.2.0.402, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.2.0.402\lib\net40\StructureMap.Net4.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StructureMap, Version=4.6.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StructureMap.4.6.1\lib\net45\StructureMap.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap.Web, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\structuremap.web.3.1.0.133\lib\net40\StructureMap.Web.dll</HintPath>

--- a/src/SFA.DAS.TokenService.Api/packages.config
+++ b/src/SFA.DAS.TokenService.Api/packages.config
@@ -30,10 +30,11 @@
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.23289" targetFramework="net45" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net45" />
-  <package id="structuremap" version="4.2.0.402" targetFramework="net45" />
+  <package id="StructureMap" version="4.6.1" targetFramework="net45" />
   <package id="StructureMap.MVC5" version="3.1.1.134" targetFramework="net45" />
   <package id="structuremap.web" version="3.1.0.133" targetFramework="net45" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.0.5" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="7.2.1" targetFramework="net45" />

--- a/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/DateTimeExtensions/GetPercentageTowardsTests.cs
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/DateTimeExtensions/GetPercentageTowardsTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh;
+
+namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.TokenRefresh.DateTimeExtensions
+{
+    [TestFixture()]
+    public class GetPercentageTowardsTests
+    {
+        public void WhenFromIsLaterThanTo_ThenShouldReturnTimeZero()
+        {
+            var fromDate = DateTime.UtcNow;
+            var toDate = fromDate.AddSeconds(-10);
+
+            Assert.AreEqual(TimeSpan.Zero, fromDate.GetPercentageTowards(toDate, 50));
+        }
+
+        [TestCase(50, 80, 40)]
+        [TestCase(100, 80, 80)]
+        [TestCase(150, 0, 0)]
+        [TestCase(150, 100, 150)]
+        public void WhenSpecifiedSecondsBetweenFromAndTo_ThenPercentageShouldBeExpectedNumberOfSeconds(int secondsBetweenFromAndTo, int gotoPercentage, int expectedTotalSeconds)
+        {
+            var fromDate = DateTime.UtcNow;
+            var toDate = fromDate.AddSeconds(secondsBetweenFromAndTo);
+
+            var timespan = fromDate.GetPercentageTowards(toDate, gotoPercentage);
+
+            Assert.AreEqual(expectedTotalSeconds, timespan.TotalSeconds);
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/TokenRefresherParametersTests.cs
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/TokenRefresherParametersTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh;
+
+namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.TokenRefresh
+{
+    [TestFixture()]
+    public class TokenRefresherParametersTests
+    {
+        [TestCase(50, 80)]
+        [TestCase(80, 80)]
+        [TestCase(90, 90)]
+        [TestCase(100, 100)]
+        [TestCase(101, 100)]
+        public void Test(int setValue, int expectedValue)
+        {
+            var parameters = new TokenRefresherParameters();
+            parameters.TokenRefreshExpirationPercentage = setValue;
+
+            Assert.AreEqual(expectedValue, parameters.TokenRefreshExpirationPercentage);
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/TokenRefresherTests/WhenBackgroundTokenRefreshRequested.cs
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/TokenRefresherTests/WhenBackgroundTokenRefreshRequested.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NLog;
+using NUnit.Framework;
+using SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh;
+using SFA.DAS.TokenService.Domain;
+
+namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.TokenRefresh.TokenRefresherTests
+{
+    [TestFixture]
+    public class WhenBackgroundTokenRefreshRequested
+    {
+        [TestCase(2000,  100, 80)]
+        [TestCase(2000,  500, 80)]
+        [TestCase(2000, 1000, 80)]
+        public async Task WeShouldNotRunRefreshInParallel(
+            int runDurationMsecs,
+            int tokenLifetimeMsecs,
+            int refreshExpirationPercentage)
+        {
+            var auditItems = await RunRefresherAndReturnCompletedRefreshInfo(runDurationMsecs, tokenLifetimeMsecs, refreshExpirationPercentage);
+
+            for (int i = 1; i < auditItems.Count; i++)
+            {
+                Assert.Greater(auditItems[i].ActualRefreshStart, auditItems[i-1].ActualRefreshEnd, "One refresh started before the previous finished");
+            }
+        }
+
+        [TestCase(2000,  250, 60)]
+        [TestCase(2000,  500, 80)]
+        [TestCase(2000, 1000, 80)]
+        public async Task WeShouldAlwaysHaveAValidToken(
+            int runDurationMsecs,
+            int tokenLifetimeMsecs,
+            int refreshExpirationPercentage)
+        {
+            var auditItems = await RunRefresherAndReturnCompletedRefreshInfo(runDurationMsecs, tokenLifetimeMsecs, refreshExpirationPercentage);
+
+            Assert.IsTrue(auditItems.All(aie => aie.ActualRefreshStart <= aie.ExpirationTime));
+        }
+
+        private async Task<List<TokenRefreshAuditEntry>> RunRefresherAndReturnCompletedRefreshInfo(
+            int runDurationMsecs,
+            int tokenLifetimeMsecs,
+            int refreshExpirationPercentage,
+            int minimumNumberOfRefreshes = 1)
+        {
+            // Arrange
+            var audit = new TokenRefreshAudit(true);
+
+            var refresher =
+                new TokenRefresher(audit, new TokenRefresherParameters { TokenRefreshExpirationPercentage = refreshExpirationPercentage });
+
+            var cancellationSource = new CancellationTokenSource(runDurationMsecs);
+            var token = AccessTokenBuilder.Create().WithValidState().ExpiresInMSecs(tokenLifetimeMsecs);
+
+            // Act
+            var refreshTask = refresher.StartTokenBackgroundRefreshAsync(token, cancellationSource.Token,
+                t =>
+                {
+                    
+                    var newToken = AccessTokenBuilder.Create().WithValidState().ExpiresInMSecs(tokenLifetimeMsecs);
+                    return Task.FromResult(newToken);
+                });
+
+            try
+            {
+                await Task.Delay(runDurationMsecs);
+                refreshTask.Wait(20); // allow a little bit extra to let the task end cleanly
+            }
+            catch (AggregateException e)
+            {
+                if (e.Flatten().InnerExceptions.Any(innerException => !(innerException is TaskCanceledException)))
+                {
+                    // We're only expecting cancellation exceptions
+                    throw;
+                }
+            }
+
+            cancellationSource.Dispose();
+            var result = audit.AuditItems
+                .Where(aie => aie.ActualRefreshStart.HasValue).OrderBy(aie => aie.ActualRefreshStart)
+                .ToList();
+
+            var estimatedMaximumNumberOfRefreshes = runDurationMsecs / tokenLifetimeMsecs * refreshExpirationPercentage;
+
+            Assert.Greater(result.Count, minimumNumberOfRefreshes, "There was an unexpectedly low number of refreshes");
+            Assert.Less(result.Count, estimatedMaximumNumberOfRefreshes, "There was an unexpectedly high number of refreshes");
+            return result;
+        }
+    }
+
+
+    public static class AccessTokenBuilder
+    {
+        public static OAuthAccessToken Create()
+        {
+            return new OAuthAccessToken();
+        }
+
+        public static OAuthAccessToken WithValidState(this OAuthAccessToken token)
+        {
+            token.WithRandomTokens();
+            token.ExpiresAt = DateTime.UtcNow.AddHours(1);
+            return token;
+        }
+
+        public static OAuthAccessToken WithRandomTokens(this OAuthAccessToken token)
+        {
+            token.AccessToken = Guid.NewGuid().ToString();
+            token.RefreshToken = Guid.NewGuid().ToString();
+            return token;
+        }
+
+        public static OAuthAccessToken ExpiresInMSecs(this OAuthAccessToken token, int msecs)
+        {
+            token.ExpiresAt = DateTime.UtcNow.AddMilliseconds(msecs);
+            return token;
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application.UnitTests/SFA.DAS.TokenService.Application.UnitTests.csproj
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/SFA.DAS.TokenService.Application.UnitTests.csproj
@@ -62,6 +62,9 @@
   <ItemGroup>
     <Compile Include="NoopExecutionPolicy.cs" />
     <Compile Include="PrivilegedAccess\GetPrivilegedAccessToken\PrivilegedAccessQueryHandlerTests\WhenHandlingPrivilegedAccessQuery.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\DateTimeExtensions\GetPercentageTowardsTests.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefresherTests\WhenBackgroundTokenRefreshRequested.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefresherParametersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -81,6 +84,7 @@
       <Name>SFA.DAS.TokenService.Infrastructure</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/GetPrivilegedAccessToken/PrivilegedAccessQueryHandler.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/GetPrivilegedAccessToken/PrivilegedAccessQueryHandler.cs
@@ -1,105 +1,22 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using MediatR;
-using NLog;
+using SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh;
 using SFA.DAS.TokenService.Domain;
-using SFA.DAS.TokenService.Domain.Data;
-using SFA.DAS.TokenService.Domain.Services;
-using SFA.DAS.TokenService.Infrastructure.ExecutionPolicies;
 
 namespace SFA.DAS.TokenService.Application.PrivilegedAccess.GetPrivilegedAccessToken
 {
     public class PrivilegedAccessQueryHandler : IAsyncRequestHandler<PrivilegedAccessQuery, OAuthAccessToken>
     {
-        private const string PrivilegedAccessSecretName = "PrivilegedAccessSecret";
-        private const string CacheKey = "OGD-TOKEN";
+        private readonly IHmrcAuthTokenBroker _hmrcAuthTokenBroker;
 
-        private readonly ISecretRepository _secretRepository;
-        private readonly ITotpService _totpService;
-        private readonly IOAuthTokenService _tokenService;
-        private readonly ICacheProvider _cacheProvider;
-        private readonly ILogger _logger;
-        private readonly ExecutionPolicy _executionPolicy;
-
-        public PrivilegedAccessQueryHandler(ISecretRepository secretRepository,
-                                            ITotpService totpService,
-                                            IOAuthTokenService tokenService,
-                                            ICacheProvider cacheProvider,
-                                            ILogger logger,
-            [RequiredPolicy(HmrcExecutionPolicy.Name)] ExecutionPolicy executionPolicy)
+        public PrivilegedAccessQueryHandler(IHmrcAuthTokenBroker hmrcAuthTokenBroker)
         {
-            _secretRepository = secretRepository;
-            _totpService = totpService;
-            _tokenService = tokenService;
-            _cacheProvider = cacheProvider;
-            _logger = logger;
-            _executionPolicy = executionPolicy;
+            _hmrcAuthTokenBroker = hmrcAuthTokenBroker;
         }
 
-        public async Task<OAuthAccessToken> Handle(PrivilegedAccessQuery message)
+        public Task<OAuthAccessToken> Handle(PrivilegedAccessQuery message)
         {
-            var accessToken = await GetToken();
-            if (accessToken.ExpiresAt <= DateTime.UtcNow)
-            {
-                accessToken = await RefreshToken(accessToken.RefreshToken);
-            }
-            return accessToken;
-        }
-
-        private async Task<OAuthAccessToken> GetToken()
-        {
-            var accessToken = await GetTokenFromCache();
-            if (accessToken == null)
-            {
-                accessToken = await GetTokenFromService();
-                await _cacheProvider.SetAsync(CacheKey, accessToken, accessToken.ExpiresAt);
-            }
-            return accessToken;
-        }
-        private async Task<OAuthAccessToken> RefreshToken(string refreshToken)
-        {
-            var accessToken = await GetTokenFromServiceUsingRefreshToken(refreshToken);
-            if (accessToken == null)
-            {
-                accessToken = await GetTokenFromService();
-            }
-            await _cacheProvider.SetAsync(CacheKey, accessToken, accessToken.ExpiresAt);
-            return accessToken;
-        }
-
-        private async Task<OAuthAccessToken> GetTokenFromCache()
-        {
-            _logger.Debug("Attempting to get privileged access token from cache");
-            var token = (OAuthAccessToken)await _cacheProvider.GetAsync(CacheKey);
-            return token;
-        }
-        private async Task<OAuthAccessToken> GetTokenFromService()
-        {
-            _logger.Debug("Attempting to get privileged access token from service");
-            var secret = await _secretRepository.GetSecretAsync(PrivilegedAccessSecretName);
-            var totp = _totpService.Generate(secret);
-            var token = await _executionPolicy.ExecuteAsync(async () => await _tokenService.GetAccessToken(totp));
-
-            _logger.Debug("Got privileged access token from service");
-            return token;
-        }
-        private async Task<OAuthAccessToken> GetTokenFromServiceUsingRefreshToken(string refreshToken)
-        {
-            try
-            {
-                _logger.Debug("Attempting to get privileged access token from service using refresh token");
-                var secret = await _secretRepository.GetSecretAsync(PrivilegedAccessSecretName);
-                var totp = _totpService.Generate(secret);
-                var token = await _executionPolicy.ExecuteAsync(async () => await _tokenService.GetAccessTokenFromRefreshToken(totp, refreshToken));
-
-                _logger.Debug("Got privileged access token from service using refresh token");
-                return token;
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn(ex, $"Error trying to refresh access token - {ex.Message}");
-                return null;
-            }
+            return _hmrcAuthTokenBroker.GetTokenAsync();
         }
     }
 }

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/DateTimeExtensions.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/DateTimeExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public static class DateTimeExtensions 
+    {
+        public static TimeSpan GetPercentageTowards(this DateTime minTime, DateTime maxTime, int requiredLeadTime)
+        {
+            if (minTime >= maxTime)
+            {
+                return TimeSpan.Zero;
+            }
+
+            var difference = (maxTime - minTime).Ticks;
+            var requiredTimeSpan = new TimeSpan(difference * requiredLeadTime / 100);
+            return requiredTimeSpan;
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBroker.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBroker.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NLog;
+using SFA.DAS.TokenService.Domain;
+using SFA.DAS.TokenService.Domain.Data;
+using SFA.DAS.TokenService.Domain.Services;
+using SFA.DAS.TokenService.Infrastructure.ExecutionPolicies;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public sealed class HmrcAuthTokenBroker : IHmrcAuthTokenBroker, IDisposable
+    {
+        private const string PrivilegedAccessSecretName = "PrivilegedAccessSecret";
+
+        private readonly ExecutionPolicy _executionPolicy;
+        private readonly ILogger _logger;
+        private readonly IOAuthTokenService _tokenService;
+        private readonly ISecretRepository _secretRepository;
+        private readonly ITotpService _totpService;
+        private readonly ITokenRefresher _tokenRefresher;
+
+        private readonly Task<OAuthAccessToken> _initialiseTask;
+        private OAuthAccessToken _cachedAccessToken;
+
+        private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+        public HmrcAuthTokenBroker(
+            [RequiredPolicy(HmrcExecutionPolicy.Name)] ExecutionPolicy executionPolicy, 
+            ILogger logger,
+            IOAuthTokenService tokenService,
+            ISecretRepository secretRepository,
+            ITotpService totpService,
+            ITokenRefresher tokenRefresher)
+        {
+            _secretRepository = secretRepository;
+            _totpService = totpService;
+            _tokenService = tokenService;
+            _logger = logger;
+            _executionPolicy = executionPolicy;
+            _tokenRefresher = tokenRefresher;
+            _initialiseTask = InitialiseToken();
+        }
+
+        public async Task<OAuthAccessToken> GetTokenAsync()
+        {
+            await _initialiseTask;
+            return _cachedAccessToken;
+        }
+
+        private Task<OAuthAccessToken> InitialiseToken()
+        {
+            return GetTokenFromServiceAsync()
+                .ContinueWith((task) =>
+                {
+                    StartTokenBackgroundRefresh(task.Result);
+                    return task.Result;
+                });
+        }
+
+        private void StartTokenBackgroundRefresh(OAuthAccessToken token)
+        {
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource = new CancellationTokenSource();
+            _tokenRefresher.StartTokenBackgroundRefreshAsync(token, _cancellationTokenSource.Token, RefreshTokenAsync);
+        }
+
+        private async Task<OAuthAccessToken> RefreshTokenAsync(OAuthAccessToken existingToken)
+        {
+            var tempToken = await GetTokenFromServiceUsingRefreshTokenAsync(existingToken) ?? await GetTokenFromServiceAsync();
+            if (tempToken != null)
+            {
+                _cachedAccessToken = tempToken;
+            } 
+
+            return _cachedAccessToken;
+        }
+
+        private async Task<OAuthAccessToken> GetTokenFromServiceUsingRefreshTokenAsync(OAuthAccessToken token)
+        {
+            try
+            {
+                _logger.Debug($"Refreshing token (expired {token.ExpiresAt})");
+                var privilegedAccessToken = await GetPrivilegedAccessToken();
+                var newToken = await _executionPolicy.ExecuteAsync(async () => await _tokenService.GetAccessTokenFromRefreshToken(privilegedAccessToken, token.RefreshToken));
+                return newToken;
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, $"Error trying to refresh access token - {ex.Message}");
+                return null;
+            }
+        }
+
+        private async Task<OAuthAccessToken> GetTokenFromServiceAsync()
+        {
+            var privilegedAccessToken = await GetPrivilegedAccessToken();
+            var tempToken = await _executionPolicy.ExecuteAsync(async () => await _tokenService.GetAccessToken(privilegedAccessToken));
+            if(tempToken != null)
+            {
+                _cachedAccessToken = tempToken;
+            }
+            return _cachedAccessToken;
+        }
+
+        private async Task<string> GetPrivilegedAccessToken()
+        {
+            _logger.Debug("Attempting to get privileged access token from service using refresh token");
+            var secret = await _secretRepository.GetSecretAsync(PrivilegedAccessSecretName);
+            var privilegedToken = _totpService.Generate(secret);
+            _logger.Debug("Attempting to get privileged access token from service using refresh token");
+            return privilegedToken;
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBroker.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBroker.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
         private readonly Task<OAuthAccessToken> _initialiseTask;
         private OAuthAccessToken _cachedAccessToken;
 
-        private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource _cancellationTokenSource;
 
         public HmrcAuthTokenBroker(
             [RequiredPolicy(HmrcExecutionPolicy.Name)] ExecutionPolicy executionPolicy, 
@@ -60,7 +60,7 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
 
         private void StartTokenBackgroundRefresh(OAuthAccessToken token)
         {
-            _cancellationTokenSource.Cancel();
+            DisposeCancellationToken();
             _cancellationTokenSource = new CancellationTokenSource();
             _tokenRefresher.StartTokenBackgroundRefreshAsync(token, _cancellationTokenSource.Token, RefreshTokenAsync);
         }
@@ -114,8 +114,18 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
 
         public void Dispose()
         {
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource.Dispose();
+            DisposeCancellationToken();
+        }
+
+        public void DisposeCancellationToken()
+        {
+            if (_cancellationTokenSource != null)
+            {
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Dispose();
+            }
+
+            _cancellationTokenSource = null;
         }
     }
 }

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/IHmrcAuthTokenBroker.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/IHmrcAuthTokenBroker.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using SFA.DAS.TokenService.Domain;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    /// <summary>
+    ///     Provides access to an automatically refreshed token. The returned value should 
+    ///     be considered short lived and re-fetched when needed - it should not be cached
+    ///     locally.
+    /// </summary>
+    public interface IHmrcAuthTokenBroker
+    {
+        /// <summary>
+        ///     Returns a task that returns the current oauth token.
+        /// </summary>
+        /// <remarks>
+        ///     The task will normally be a completed task, which .net will use
+        ///     to optimise by avoiding the unncessary thread switch when used
+        ///     in async/await scenarios. 
+        /// </remarks>
+        /// <returns></returns>
+        Task<OAuthAccessToken> GetTokenAsync();
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/ITokenRefreshAudit.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/ITokenRefreshAudit.cs
@@ -15,8 +15,8 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
     public interface ITokenRefreshAudit
     {
         TokenRefreshAuditEntry CreateAuditEntry(OAuthAccessToken token);
-        void StartRefresh(TokenRefreshAuditEntry auditEntry);
-        void EndRefresh(TokenRefreshAuditEntry auditEntry);
+        void RefreshStarted(TokenRefreshAuditEntry auditEntry);
+        void RefreshEnded(TokenRefreshAuditEntry auditEntry);
         IEnumerable<TokenRefreshAuditEntry> AuditItems { get; }
     }
 }

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/ITokenRefreshAudit.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/ITokenRefreshAudit.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using SFA.DAS.TokenService.Domain;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    /// <summary>
+    ///     Provides a means for the auditing the token refresh attempts
+    /// </summary>
+    /// <remarks>
+    ///     The motivation for this was to allow unit tests to verify the 
+    ///     behaviour of the token refresher. 
+    ///     In production the audit items are not preserved to avoid these
+    ///     building up over long running processes.
+    /// </remarks>
+    public interface ITokenRefreshAudit
+    {
+        TokenRefreshAuditEntry CreateAuditEntry(OAuthAccessToken token);
+        void StartRefresh(TokenRefreshAuditEntry auditEntry);
+        void EndRefresh(TokenRefreshAuditEntry auditEntry);
+        IEnumerable<TokenRefreshAuditEntry> AuditItems { get; }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/ITokenRefresher.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/ITokenRefresher.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SFA.DAS.TokenService.Domain;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    /// <summary>
+    ///     Represents a service that will keep refreshing the supplied token until the 
+    ///     cancellation token is set cancelled.
+    /// </summary>
+    /// <remarks>
+    ///     The concrete implementation (<see cref="TokenRefresher"/> will start refreshing
+    ///     the token when it is 80% towards the end of its life (see <see cref="TokenRefresherParameters.TokenRefreshExpirationPercentage"/>).
+    ///     Once successfully refreshed the existing token will be swapped out.
+    /// </remarks>
+    public interface ITokenRefresher
+    {
+        /// <summary>
+        ///     Starts a background task that will run indefinitely refreshing the supplied token.
+        /// </summary>
+        /// <param name="token">The original token</param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token provided by the caller. This should be cancelled when the caller is closing 
+        ///     down.
+        /// </param>
+        /// <param name="refreshToken">
+        ///     A delegate that will be called to refresh the token when the existing token is getting towards
+        ///     the end of its life.
+        /// </param>
+        /// <returns>
+        ///     The background task. This should probably not be awaited as it will run for a long time.
+        /// </returns>
+        Task StartTokenBackgroundRefreshAsync(
+            OAuthAccessToken token, 
+            CancellationToken cancellationToken,
+            Func<OAuthAccessToken, Task<OAuthAccessToken>> refreshToken);
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefreshAudit.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefreshAudit.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using SFA.DAS.TokenService.Domain;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public class TokenRefreshAudit : ITokenRefreshAudit
+    {
+        private readonly List<TokenRefreshAuditEntry> _auditEntries;
+
+        private readonly bool _maintainList;
+
+        public TokenRefreshAudit(bool maintainList = false)
+        {
+            _maintainList = maintainList;
+            if (maintainList)
+            {
+                _auditEntries = new List<TokenRefreshAuditEntry>();
+            }
+        }
+
+        public TokenRefreshAuditEntry CreateAuditEntry(OAuthAccessToken token)
+        {
+            var result = new TokenRefreshAuditEntry
+            {
+                ExpirationTime = token.ExpiresAt
+            };
+
+            if (_maintainList)
+            {
+                _auditEntries.Add(result);
+            }
+
+            return result;
+        }
+
+        public void StartRefresh(TokenRefreshAuditEntry auditEntry)
+        {
+            auditEntry.ActualRefreshStart = DateTime.UtcNow;
+        }
+
+        public void EndRefresh(TokenRefreshAuditEntry auditEntry)
+        {
+            auditEntry.ActualRefreshEnd = DateTime.UtcNow;
+        }
+
+        public IEnumerable<TokenRefreshAuditEntry> AuditItems => _auditEntries;
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefreshAudit.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefreshAudit.cs
@@ -34,12 +34,12 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
             return result;
         }
 
-        public void StartRefresh(TokenRefreshAuditEntry auditEntry)
+        public void RefreshStarted(TokenRefreshAuditEntry auditEntry)
         {
             auditEntry.ActualRefreshStart = DateTime.UtcNow;
         }
 
-        public void EndRefresh(TokenRefreshAuditEntry auditEntry)
+        public void RefreshEnded(TokenRefreshAuditEntry auditEntry)
         {
             auditEntry.ActualRefreshEnd = DateTime.UtcNow;
         }

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefreshAuditEntry.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefreshAuditEntry.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public class TokenRefreshAuditEntry
+    {
+        public DateTime ExpirationTime { get; set; }
+        public TimeSpan PlannedRefreshDelay { get; set; }
+        public DateTime PlannedRefreshTime { get; set; }
+        public DateTime? ActualRefreshStart { get; set; }
+        public DateTime? ActualRefreshEnd { get; set; }
+        public int RefreshAttemps { get; set; }
+        public bool Overdue => ActualRefreshStart.HasValue && ActualRefreshStart.Value > ExpirationTime;
+        public override string ToString()
+        {
+            var refreshTime = ActualRefreshStart?.ToString("HH:mm: ss.fff") ?? "n/a";
+
+            return $"Expiration:{ExpirationTime:HH:mm:ss.fff} " +
+                   $"Refresh:{PlannedRefreshDelay.TotalMilliseconds} ({PlannedRefreshTime:HH:mm:ss.fff}) " +
+                   $"ActualRefresh:{refreshTime} " +
+                   $"Refresh-attempts:{RefreshAttemps} " +
+                   $"Overdue:{Overdue}";
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresher.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresher.cs
@@ -43,7 +43,7 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
 
             if (!cancellationToken.IsCancellationRequested)
             {
-                _refreshAudit.StartRefresh(auditItem);
+                _refreshAudit.RefreshStarted(auditItem);
 
                 OAuthAccessToken newToken = await TryRefreshUntilCancelledOrSuccess(
                                                         auditItem, 
@@ -51,7 +51,7 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
                                                         cancellationToken, 
                                                         refreshToken);
 
-                _refreshAudit.EndRefresh(auditItem);
+                _refreshAudit.RefreshEnded(auditItem);
                 return newToken;
             }
 

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresher.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresher.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SFA.DAS.TokenService.Domain;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public class TokenRefresher : ITokenRefresher
+    {
+        private readonly TokenRefresherParameters _parameters;
+        private readonly ITokenRefreshAudit _refreshAudit;
+
+        public TokenRefresher(
+            ITokenRefreshAudit refreshAudit,
+            TokenRefresherParameters parameters)
+        {
+            _parameters = parameters;
+            _refreshAudit = refreshAudit;
+        }
+
+        public Task StartTokenBackgroundRefreshAsync(
+            OAuthAccessToken token, 
+            CancellationToken cancellationToken, 
+            Func<OAuthAccessToken, Task<OAuthAccessToken>> refreshToken)
+        {
+            return Task.Run(async () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    token = await WaitAndThenRefreshAsync(token, cancellationToken, refreshToken);
+                }
+            }, cancellationToken);
+        }
+
+        private async Task<OAuthAccessToken> WaitAndThenRefreshAsync(
+            OAuthAccessToken token,
+            CancellationToken cancellationToken, 
+            Func<OAuthAccessToken, Task<OAuthAccessToken>> refreshToken)
+        {
+            var auditItem = _refreshAudit.CreateAuditEntry(token);
+
+            await WaitForRefreshTimeAsync(token, cancellationToken, auditItem);
+
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                _refreshAudit.StartRefresh(auditItem);
+
+                OAuthAccessToken newToken = await TryRefreshUntilCancelledOrSuccess(
+                                                        auditItem, 
+                                                        token, 
+                                                        cancellationToken, 
+                                                        refreshToken);
+
+                _refreshAudit.EndRefresh(auditItem);
+                return newToken;
+            }
+
+            return null;
+        }
+
+        private async Task<OAuthAccessToken> TryRefreshUntilCancelledOrSuccess(
+            TokenRefreshAuditEntry auditItem,
+            OAuthAccessToken token,
+            CancellationToken cancellationToken,
+            Func<OAuthAccessToken, Task<OAuthAccessToken>> refreshToken)
+        {
+            OAuthAccessToken newToken;
+
+            do
+            {
+                auditItem.RefreshAttemps++;
+                newToken = await TryRefresh(token, cancellationToken, refreshToken);
+                if (newToken == null)
+                {
+                    await Task.Delay(_parameters.RetryInterval, cancellationToken);
+                }
+            } while (newToken == null && !cancellationToken.IsCancellationRequested);
+
+            return newToken;
+        }
+
+        private Task<OAuthAccessToken> TryRefresh(
+            OAuthAccessToken token,
+            CancellationToken cancellationToken,
+            Func<OAuthAccessToken, Task<OAuthAccessToken>> refreshToken)
+        {
+            try
+            {
+                return refreshToken(token);
+            }
+            catch (Exception e)
+            {
+                // we need to keep trying
+                return Task.FromResult<OAuthAccessToken>(null);
+            }
+        }
+
+        //TODO: not using 4.6.2 so Task.Completed not available
+        private readonly Task _completedTask = Task.Run(() => {});
+
+        private Task WaitForRefreshTimeAsync(OAuthAccessToken token, CancellationToken cancellationToken, TokenRefreshAuditEntry auditItem)
+        {
+            var delay = DateTime.UtcNow.GetPercentageTowards(token.ExpiresAt, _parameters.TokenRefreshExpirationPercentage);
+            auditItem.PlannedRefreshDelay = delay;
+
+            if (delay == TimeSpan.Zero)
+            {
+                return _completedTask;
+            }
+
+            return Task.Delay(delay, cancellationToken);
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresher.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresher.cs
@@ -69,7 +69,7 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
             do
             {
                 auditItem.RefreshAttemps++;
-                newToken = await TryRefresh(token, cancellationToken, refreshToken);
+                newToken = await TryRefresh(token, refreshToken);
                 if (newToken == null)
                 {
                     await Task.Delay(_parameters.RetryInterval, cancellationToken);
@@ -81,14 +81,13 @@ namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
 
         private Task<OAuthAccessToken> TryRefresh(
             OAuthAccessToken token,
-            CancellationToken cancellationToken,
             Func<OAuthAccessToken, Task<OAuthAccessToken>> refreshToken)
         {
             try
             {
                 return refreshToken(token);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // we need to keep trying
                 return Task.FromResult<OAuthAccessToken>(null);

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresherParameters.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/TokenRefresherParameters.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public class TokenRefresherParameters {
+
+        public TokenRefresherParameters()
+        {
+            TokenRefreshExpirationPercentage = MaximumTokenRefreshLeadTime;
+            RetryInterval = new TimeSpan(0, 0, 10);
+        }
+
+        private int _tokenRefreshExpirationPercentage;
+
+        // The maximum amount of lead time
+        public const int MaximumTokenRefreshLeadTime = 80;
+
+        // The minimum amount of lead time.
+        public const int MinimumTokenRefreshLeadTime = 100;
+
+        /// <summary>
+        ///     The token will be refreshed automatically in the background when it's within this
+        ///     percentage of being expired. 
+        /// </summary>
+        /// <remarks>
+        ///     This must be between 80 and 100. It will be automatically adjusted to be within 
+        ///     this range. The upper limit for lead time (i.e. 80) exists to prevent unwittingly setting to 
+        ///     a low value resulting in overly eagre token refreshes.
+        /// </remarks>
+        public int TokenRefreshExpirationPercentage
+        {
+            get => _tokenRefreshExpirationPercentage;
+            set => _tokenRefreshExpirationPercentage = Math.Max(MaximumTokenRefreshLeadTime, Math.Min(MinimumTokenRefreshLeadTime, value));
+        }
+
+        /// <summary>
+        ///     The interval to leave between retrying failures. This is a wrapper around Polly retry, which will eventually give up. 
+        ///     We must keep going until we get a result. 
+        /// </summary>
+        public TimeSpan RetryInterval { get; set; }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/SFA.DAS.TokenService.Application.csproj
+++ b/src/SFA.DAS.TokenService.Application/SFA.DAS.TokenService.Application.csproj
@@ -48,8 +48,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PrivilegedAccess\TokenRefresh\DateTimeExtensions.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\HmrcAuthTokenBroker.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\IHmrcAuthTokenBroker.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\ITokenRefreshAudit.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\ITokenRefresher.cs" />
     <Compile Include="PrivilegedAccess\GetPrivilegedAccessToken\PrivilegedAccessQuery.cs" />
     <Compile Include="PrivilegedAccess\GetPrivilegedAccessToken\PrivilegedAccessQueryHandler.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefreshAudit.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefreshAuditEntry.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefresher.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefresherParameters.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.TokenService.Infrastructure/Data/KeyVaultSecretRepository.cs
+++ b/src/SFA.DAS.TokenService.Infrastructure/Data/KeyVaultSecretRepository.cs
@@ -8,6 +8,15 @@ using SFA.DAS.TokenService.Infrastructure.Configuration;
 
 namespace SFA.DAS.TokenService.Infrastructure.Data
 {
+#if UseDummyTokens
+    public class DummySecretRepository : ISecretRepository
+    {
+        public Task<string> GetSecretAsync(string name)
+        {
+            return Task.FromResult(name);
+        }
+    }
+#else
     public class KeyVaultSecretRepository : ISecretRepository
     {
         private readonly KeyVaultConfiguration _configuration;
@@ -45,4 +54,5 @@ namespace SFA.DAS.TokenService.Infrastructure.Data
             return authenticationResult.AccessToken;
         }
     }
+#endif
 }

--- a/src/SFA.DAS.TokenService.Infrastructure/Data/KeyVaultSecretRepository.cs
+++ b/src/SFA.DAS.TokenService.Infrastructure/Data/KeyVaultSecretRepository.cs
@@ -8,15 +8,6 @@ using SFA.DAS.TokenService.Infrastructure.Configuration;
 
 namespace SFA.DAS.TokenService.Infrastructure.Data
 {
-#if UseDummyTokens
-    public class DummySecretRepository : ISecretRepository
-    {
-        public Task<string> GetSecretAsync(string name)
-        {
-            return Task.FromResult(name);
-        }
-    }
-#else
     public class KeyVaultSecretRepository : ISecretRepository
     {
         private readonly KeyVaultConfiguration _configuration;
@@ -54,5 +45,4 @@ namespace SFA.DAS.TokenService.Infrastructure.Data
             return authenticationResult.AccessToken;
         }
     }
-#endif
 }

--- a/src/SFA.DAS.TokenService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
+++ b/src/SFA.DAS.TokenService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web;
+using NLog;
 using Polly;
 using SFA.DAS.EAS.Infrastructure.ExecutionPolicies;
-using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.TokenService.Infrastructure.ExecutionPolicies
 {
@@ -15,14 +11,14 @@ namespace SFA.DAS.TokenService.Infrastructure.ExecutionPolicies
     {
         public const string Name = "HMRC Policy";
 
-        private readonly ILog _logger;
+        private readonly ILogger _logger;
         private readonly Policy TooManyRequestsPolicy;
         private readonly Policy ServiceUnavailablePolicy;
         private readonly Policy InternalServerErrorPolicy;
         private readonly Policy RequestTimeoutPolicy;
         private readonly Policy UnauthorizedPolicy;
 
-        public HmrcExecutionPolicy(ILog logger)
+        public HmrcExecutionPolicy(ILogger logger)
         {
             _logger = logger;
 

--- a/src/SFA.DAS.TokenService.Infrastructure/SFA.DAS.TokenService.Infrastructure.csproj
+++ b/src/SFA.DAS.TokenService.Infrastructure/SFA.DAS.TokenService.Infrastructure.csproj
@@ -76,13 +76,8 @@
       <HintPath>..\packages\simonbu11.otp.1.2.0\lib\net45\Simonbu11.Otp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=4.2.0.402, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.2.0.402\lib\net40\StructureMap.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="StructureMap.Net4, Version=4.2.0.402, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.2.0.402\lib\net40\StructureMap.Net4.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StructureMap, Version=4.6.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StructureMap.4.6.1\lib\net45\StructureMap.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SFA.DAS.TokenService.Infrastructure/Services/OAuthTokenService.cs
+++ b/src/SFA.DAS.TokenService.Infrastructure/Services/OAuthTokenService.cs
@@ -8,34 +8,6 @@ using SFA.DAS.TokenService.Infrastructure.Http;
 
 namespace SFA.DAS.TokenService.Infrastructure.Services
 {
-#if UseDummyTokens
-    public class DummyTokenService : IOAuthTokenService
-    {
-        private static int calls = 0;
-
-        public Task<OAuthAccessToken> GetAccessToken(string clientSecret)
-        {
-            var i = Interlocked.Increment(ref calls);
-            return Task.FromResult(new OAuthAccessToken
-            {
-                AccessToken = $"token_{i}",
-                ExpiresAt = DateTime.UtcNow.AddSeconds(15),
-                RefreshToken = $"refresh_{i}"
-            });
-        }
-
-        public Task<OAuthAccessToken> GetAccessTokenFromRefreshToken(string clientSecret, string refreshToken)
-        {
-            var i = Interlocked.Increment(ref calls);
-            return Task.FromResult(new OAuthAccessToken
-            {
-                AccessToken = $"token_{i}",
-                ExpiresAt = DateTime.UtcNow.AddSeconds(15),
-                RefreshToken = $"refresh_{i}"
-            });
-        }
-    }
-#else
     public class OAuthTokenService : IOAuthTokenService
     {
         private readonly IHttpClientWrapper _httpClient;
@@ -90,5 +62,4 @@ namespace SFA.DAS.TokenService.Infrastructure.Services
             };
         }
     }
-#endif
 }

--- a/src/SFA.DAS.TokenService.Infrastructure/Services/OAuthTokenService.cs
+++ b/src/SFA.DAS.TokenService.Infrastructure/Services/OAuthTokenService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using SFA.DAS.TokenService.Domain;
 using SFA.DAS.TokenService.Domain.Services;
@@ -7,6 +8,34 @@ using SFA.DAS.TokenService.Infrastructure.Http;
 
 namespace SFA.DAS.TokenService.Infrastructure.Services
 {
+#if UseDummyTokens
+    public class DummyTokenService : IOAuthTokenService
+    {
+        private static int calls = 0;
+
+        public Task<OAuthAccessToken> GetAccessToken(string clientSecret)
+        {
+            var i = Interlocked.Increment(ref calls);
+            return Task.FromResult(new OAuthAccessToken
+            {
+                AccessToken = $"token_{i}",
+                ExpiresAt = DateTime.UtcNow.AddSeconds(15),
+                RefreshToken = $"refresh_{i}"
+            });
+        }
+
+        public Task<OAuthAccessToken> GetAccessTokenFromRefreshToken(string clientSecret, string refreshToken)
+        {
+            var i = Interlocked.Increment(ref calls);
+            return Task.FromResult(new OAuthAccessToken
+            {
+                AccessToken = $"token_{i}",
+                ExpiresAt = DateTime.UtcNow.AddSeconds(15),
+                RefreshToken = $"refresh_{i}"
+            });
+        }
+    }
+#else
     public class OAuthTokenService : IOAuthTokenService
     {
         private readonly IHttpClientWrapper _httpClient;
@@ -61,4 +90,5 @@ namespace SFA.DAS.TokenService.Infrastructure.Services
             };
         }
     }
+#endif
 }

--- a/src/SFA.DAS.TokenService.Infrastructure/packages.config
+++ b/src/SFA.DAS.TokenService.Infrastructure/packages.config
@@ -13,5 +13,6 @@
   <package id="Polly" version="5.3.1" targetFramework="net45" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net45" />
   <package id="simonbu11.otp" version="1.2.0" targetFramework="net45" />
-  <package id="structuremap" version="4.2.0.402" targetFramework="net45" />
+  <package id="StructureMap" version="4.6.1" targetFramework="net45" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The previous token refresh code had two problems contributing towards AML-1608;
1. a race condition existed in that multiple requests could be fired off to refresh the HMRC token as they all competed to refresh stale tokens
2. tokens were refreshed at the instant they were discovered to be dead, which if HMRC was unavailable for a period of time (which from the logs seems to be a frequent - at least daily - event) would leave the token service unable to satisfy requests.

This change:
1. Ensures that token requests are brokered
2. They are refreshed ahead of time (80% towards end of life), allowing some opportunity for recovery.
