### PR TITLE
Modify startup to persist in getting a token until HMRC reports success

### DIFF
--- a/src/SFA.DAS.TokenService.Api/Controllers/PrivilegedAccessController.cs
+++ b/src/SFA.DAS.TokenService.Api/Controllers/PrivilegedAccessController.cs
@@ -22,7 +22,6 @@ namespace SFA.DAS.TokenService.Api.Controllers
 
         [HttpGet]
         [Route("", Name = "GetPrivilegedAccessToken")]
-        //[Authorize(Roles = "ReadPrivilegedAccessToken")]
         [Authorize]
         public async Task<IHttpActionResult> GetPrivilegedAccessToken()
         {

--- a/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/GetPrivilegedAccessToken/PrivilegedAccessQueryHandlerTests/WhenHandlingPrivilegedAccessQuery.cs
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/GetPrivilegedAccessToken/PrivilegedAccessQueryHandlerTests/WhenHandlingPrivilegedAccessQuery.cs
@@ -41,6 +41,7 @@ namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.GetPrivile
         private PrivilegedAccessQuery _query;
         private Mock<ILogger> _logger;
         private Mock<ITokenRefresher> _tokenRefresher;
+        private Mock<IHmrcAuthTokenBrokerConfig> _hmrcAuthBrokenConfig;
 
         [SetUp]
         public void Arrange()
@@ -52,6 +53,9 @@ namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.GetPrivile
             _totpService = new Mock<ITotpService>();
             _totpService.Setup(g => g.Generate(OgdSecret))
                 .Returns(TotpCode);
+
+            _hmrcAuthBrokenConfig = new Mock<IHmrcAuthTokenBrokerConfig>();
+            _hmrcAuthBrokenConfig.Setup(config => config.RetryDelay).Returns(TimeSpan.FromSeconds(0));
 
             _oauthTokenService = new Mock<IOAuthTokenService>();
             _oauthTokenService.Setup(s => s.GetAccessToken(TotpCode))
@@ -83,7 +87,8 @@ namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.GetPrivile
                 _oauthTokenService.Object,
                 _secretRepository.Object,
                 _totpService.Object,
-                _tokenRefresher.Object
+                _tokenRefresher.Object,
+                _hmrcAuthBrokenConfig.Object
             );
 
             _handler = new PrivilegedAccessQueryHandler(hmrcAuthTokenContainer);

--- a/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBrokerTests.cs
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBrokerTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh;
+using SFA.DAS.TokenService.Domain.Data;
+using SFA.DAS.TokenService.Domain.Services;
+using NLog;
+using SFA.DAS.TokenService.Domain;
+using SFA.DAS.TokenService.Infrastructure.ExecutionPolicies;
+
+namespace SFA.DAS.TokenService.Application.UnitTests.PrivilegedAccess.TokenRefresh
+{
+    [TestFixture]
+    public class HmrcAuthTokenBrokerTests 
+    {
+        [Test]
+        public async Task GetTokenAsync_InitialRequestFails_ShouldStillGoOnToGetToken()
+        {
+            var fixtures = new HmrcAuthTokenBrokerTestFixtures()
+                .WithInitialTaskResult(() => throw new HttpRequestException("Initial token request has failed"));
+
+            var svc = fixtures.CreateHmrcAuthTokenBroker();
+
+            var accessToken = await svc.GetTokenAsync();
+
+            Assert.IsNotNull(accessToken);
+        }
+
+        [Test]
+        public async Task GetTokenAsync_InitialThreeRequestFail_ShouldStillGoOnToGetToken()
+        {
+            var fixtures = new HmrcAuthTokenBrokerTestFixtures()
+                .WithInitialTaskResult(() => throw new HttpRequestException("Initial token request has failed"))
+                .WithInitialTaskResult(() => throw new HttpRequestException("Initial token request has failed"))
+                .WithInitialTaskResult(() => null);
+
+            var svc = fixtures.CreateHmrcAuthTokenBroker();
+
+            var accessToken = await svc.GetTokenAsync();
+
+            Assert.IsNotNull(accessToken);
+        }
+
+        [Test]
+        public async Task GetTokenAsync_InitialThreeRequestFail_ShouldCallPostFourTimes()
+        {
+            var fixtures = new HmrcAuthTokenBrokerTestFixtures()
+                .WithInitialTaskResult(() => throw new HttpRequestException("Initial token request has failed"))
+                .WithInitialTaskResult(() => throw new HttpRequestException("Initial token request has failed"))
+                .WithInitialTaskResult(() => null);
+
+            var svc = fixtures.CreateHmrcAuthTokenBroker();
+
+            var accessToken = await svc.GetTokenAsync();
+
+            fixtures.OAuthTokenServiceMock.Verify(ots => ots.GetAccessToken(It.IsAny<string>()), Times.Exactly(4));
+        }
+
+        [Test]
+        public async Task GetTokenAsync_WhenFirstRequestFails_ShouldCallPostTwice()
+        {
+            var fixtures = new HmrcAuthTokenBrokerTestFixtures()
+                .WithInitialTaskResult(() => throw new HttpRequestException("Initial token request has failed"));
+
+            var svc = fixtures.CreateHmrcAuthTokenBroker();
+
+            var accessToken = await svc.GetTokenAsync();
+
+            fixtures.OAuthTokenServiceMock.Verify(ots => ots.GetAccessToken(It.IsAny<string>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public async Task GetTokenAsync_WhenFirstSucceeds_ShouldReturnExpectedToken()
+        {
+            var accessToken = Guid.NewGuid().ToString();
+            var refreshToken = Guid.NewGuid().ToString();
+
+            var fixtures = new HmrcAuthTokenBrokerTestFixtures()
+                .WithInitialTaskResult(() => new OAuthAccessToken
+                {
+                    AccessToken = accessToken,
+                    RefreshToken = refreshToken
+                });
+
+            var svc = fixtures.CreateHmrcAuthTokenBroker();
+
+            var token = await svc.GetTokenAsync();
+
+            Assert.AreEqual(accessToken, token.AccessToken, "Access token is not the expected value");
+            Assert.AreEqual(refreshToken, token.RefreshToken, "Refresh token is not the expected value");
+        }
+    }
+
+    public class HmrcAuthTokenBrokerTestFixtures
+    {
+        public HmrcAuthTokenBrokerTestFixtures()
+        {
+            LoggerMock = new Mock<ILogger>();
+            OAuthTokenServiceMock = new Mock<IOAuthTokenService>();
+            SecretRepositoryMock = new Mock<ISecretRepository>();
+            TotpServiceMock = new Mock<ITotpService>();
+            TokenRefresherMock = new Mock<ITokenRefresher>();
+            HmrcAuthTokenBrokerConfigMock = new Mock<IHmrcAuthTokenBrokerConfig>();
+
+            AccessTokenRequests = new Queue<Func<OAuthAccessToken>>();
+
+            HmrcAuthTokenBrokerConfigMock.Setup(config => config.RetryDelay).Returns(TimeSpan.Zero);
+
+            OAuthTokenServiceMock
+                .Setup(ots => ots.GetAccessToken(It.IsAny<string>()))
+                .Returns(() =>
+                {
+                    var func = AccessTokenRequests.Dequeue();
+                    return Task.FromResult(func());
+                });
+        }
+
+        public Mock<NLog.ILogger> LoggerMock { get; }
+        public NLog.ILogger Logger => LoggerMock.Object;
+
+        public Mock<IOAuthTokenService> OAuthTokenServiceMock { get; }
+        public IOAuthTokenService OAuthTokenService => OAuthTokenServiceMock.Object;
+
+        public Mock<ISecretRepository> SecretRepositoryMock { get;  }
+        public ISecretRepository SecretRepository => SecretRepositoryMock.Object;
+
+        public Mock<ITotpService> TotpServiceMock { get; }
+        public ITotpService TotpService => TotpServiceMock.Object;
+
+        public Mock<ITokenRefresher> TokenRefresherMock { get;  }
+        public ITokenRefresher TokenRefresher => TokenRefresherMock.Object;
+
+        public Mock<IHmrcAuthTokenBrokerConfig> HmrcAuthTokenBrokerConfigMock { get; set; }
+        public IHmrcAuthTokenBrokerConfig HmrcAuthTokenBrokerConfig => HmrcAuthTokenBrokerConfigMock.Object;
+
+        public Queue<Func<OAuthAccessToken>> AccessTokenRequests { get; }
+
+        public HmrcAuthTokenBrokerTestFixtures WithInitialTaskResult(Func<OAuthAccessToken> getter)
+        {
+            AccessTokenRequests.Enqueue(getter);
+            return this;
+        }
+
+        public HmrcAuthTokenBroker CreateHmrcAuthTokenBroker()
+        {
+            // Make sure that the queue is terminated with a 
+            WithInitialTaskResult(() => new OAuthAccessToken
+            {
+                AccessToken = "AccessToken",
+                ExpiresAt = DateTime.Now.AddMinutes(30),
+                RefreshToken = "RefreshToken"
+            });
+
+            return new HmrcAuthTokenBroker(
+                new HmrcExecutionPolicy(Logger), 
+                Logger,
+                OAuthTokenService, 
+                SecretRepository,
+                TotpService,
+                TokenRefresher,
+                HmrcAuthTokenBrokerConfig
+                );
+        }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application.UnitTests/SFA.DAS.TokenService.Application.UnitTests.csproj
+++ b/src/SFA.DAS.TokenService.Application.UnitTests/SFA.DAS.TokenService.Application.UnitTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="NoopExecutionPolicy.cs" />
     <Compile Include="PrivilegedAccess\GetPrivilegedAccessToken\PrivilegedAccessQueryHandlerTests\WhenHandlingPrivilegedAccessQuery.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\DateTimeExtensions\GetPercentageTowardsTests.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\HmrcAuthTokenBrokerTests.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefresherTests\WhenBackgroundTokenRefreshRequested.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\TokenRefresherParametersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBrokerConfig.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/HmrcAuthTokenBrokerConfig.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public class HmrcAuthTokenBrokerConfig : IHmrcAuthTokenBrokerConfig
+    {
+        public HmrcAuthTokenBrokerConfig()
+        {
+            RetryDelay = TimeSpan.FromSeconds(30);    
+        }
+
+        public TimeSpan RetryDelay { get; set; }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/IHmrcAuthTokenBrokerConfig.cs
+++ b/src/SFA.DAS.TokenService.Application/PrivilegedAccess/TokenRefresh/IHmrcAuthTokenBrokerConfig.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SFA.DAS.TokenService.Application.PrivilegedAccess.TokenRefresh
+{
+    public interface IHmrcAuthTokenBrokerConfig
+    {
+        TimeSpan RetryDelay { get; }
+    }
+}

--- a/src/SFA.DAS.TokenService.Application/SFA.DAS.TokenService.Application.csproj
+++ b/src/SFA.DAS.TokenService.Application/SFA.DAS.TokenService.Application.csproj
@@ -50,7 +50,9 @@
   <ItemGroup>
     <Compile Include="PrivilegedAccess\TokenRefresh\DateTimeExtensions.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\HmrcAuthTokenBroker.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\HmrcAuthTokenBrokerConfig.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\IHmrcAuthTokenBroker.cs" />
+    <Compile Include="PrivilegedAccess\TokenRefresh\IHmrcAuthTokenBrokerConfig.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\ITokenRefreshAudit.cs" />
     <Compile Include="PrivilegedAccess\TokenRefresh\ITokenRefresher.cs" />
     <Compile Include="PrivilegedAccess\GetPrivilegedAccessToken\PrivilegedAccessQuery.cs" />


### PR DESCRIPTION
Amend the startup behaviour so that we keep trying HMRC indefinitely to get a token, rather than just relying on Poly.